### PR TITLE
Rename gem to active_encode; fixes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This gem serves as the basis for the interface between a Ruby (Rails) applicatio
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'active-encode'
+gem 'active_encode'
 ```
 
 And then execute:
@@ -16,7 +16,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install active-encode
+    $ gem install active_encode
 
 ## Usage
 
@@ -99,7 +99,7 @@ Engine adapters are shims between ActiveEncode and the back end encoding service
 
 ## Contributing
 
-1. Fork it ( https://github.com/[my-github-username]/active-encode/fork )
+1. Fork it ( https://github.com/projecthydra-labs/active_encode/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/active_encode.gemspec
+++ b/active_encode.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'active_encode/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "active-encode"
+  spec.name          = "active_encode"
   spec.version       = ActiveEncode::VERSION
   spec.authors       = ["Michael Klein, Chris Colvard"]
   spec.email         = ["mbklein@gmail.com, chris.colvard@gmail.com"]

--- a/lib/active-encode.rb
+++ b/lib/active-encode.rb
@@ -1,1 +1,0 @@
-require 'active_encode'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ Bundler.setup
 
 require 'byebug'
 require 'rspec/its'
-require 'active-encode'
+require 'active_encode'
 
 RSpec.configure do |_config|
 end


### PR DESCRIPTION
After merging, this repository should be renamed and a new release under the new name should be made.