### PR TITLE
Test on latest ruby/rails and drop unsupported versions and release prep

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,38 +75,26 @@ workflows:
   ci:
     jobs:
       - bundle_and_test:
+          name: "ruby4-0_rails8-1"
+          ruby_version: "4.0.2"
+          rails_version: "8.1.3"
+      - bundle_and_test:
+          name: "ruby4-0_rails8-0"
+          ruby_version: "4.0.2"
+          rails_version: "8.0.5"
+      - bundle_and_test:
           name: "ruby3-4_rails8-0"
-          ruby_version: "3.4.1"
-          rails_version: "8.0.1"
+          ruby_version: "3.4.9"
+          rails_version: "8.0.5"
       - bundle_and_test:
           name: "ruby3-4_rails7-2"
-          ruby_version: "3.4.1"
-          rails_version: "7.2.2.1"
-      - bundle_and_test:
-          name: "ruby3-4_rails7-1"
-          ruby_version: "3.4.1"
-          rails_version: "7.1.5.1"
+          ruby_version: "3.4.9"
+          rails_version: "7.2.3.1"
       - bundle_and_test:
           name: "ruby3-3_rails8-0"
-          ruby_version: "3.3.7"
-          rails_version: "8.0.1"
+          ruby_version: "3.3.11"
+          rails_version: "8.0.5"
       - bundle_and_test:
           name: "ruby3-3_rails7-2"
-          ruby_version: "3.3.7"
-          rails_version: "7.2.2.1"
-      - bundle_and_test:
-          name: "ruby3-3_rails7-1"
-          ruby_version: "3.3.7"
-          rails_version: "7.1.5.1"
-      - bundle_and_test:
-          name: "ruby3-2_rails8-0"
-          ruby_version: "3.2.7"
-          rails_version: "8.0.1"
-      - bundle_and_test:
-          name: "ruby3-2_rails7-2"
-          ruby_version: "3.2.7"
-          rails_version: "7.2.2.1"
-      - bundle_and_test:
-          name: "ruby3-2_rails7-1"
-          ruby_version: "3.2.7"
-          rails_version: "7.1.5.1"
+          ruby_version: "3.3.11"
+          rails_version: "7.2.3.1"

--- a/active_encode.gemspec
+++ b/active_encode.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "aws-sdk-elastictranscoder"
   spec.add_development_dependency "aws-sdk-mediaconvert", ">= 1.157.0"
   spec.add_development_dependency "aws-sdk-s3"
+  spec.add_development_dependency "benchmark" # Needed for bixby/rubocop with ruby 4+
   spec.add_development_dependency "bixby", '~> 5.0', '>= 5.0.2'
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "coveralls"

--- a/lib/active_encode/version.rb
+++ b/lib/active_encode/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ActiveEncode
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end

--- a/spec/controllers/encode_record_controller_spec.rb
+++ b/spec/controllers/encode_record_controller_spec.rb
@@ -46,7 +46,7 @@ describe ActiveEncode::EncodeRecordController, type: :controller, db_clean: true
       end
 
       it "returns the encode record's raw json object" do
-        expect(response.body).to eq "{\"message\":\"Couldn't find ActiveEncode::EncodeRecord with 'id'=#{record_id}\"}"
+        expect(response.body).to eq "{\"message\":\"Couldn't find ActiveEncode::EncodeRecord with 'id'=\\\"#{record_id}\\\"\"}"
       end
     end
   end


### PR DESCRIPTION
Bump version to 2.0.1
Included PRs in release:
- #157 