### PR TITLE
Add label to end of pass-through filenames

### DIFF
--- a/lib/active_encode/engine_adapters/pass_through_adapter.rb
+++ b/lib/active_encode/engine_adapters/pass_through_adapter.rb
@@ -74,7 +74,7 @@ module ActiveEncode
 
         # Copy derivatives to work directory
         options[:outputs].each do |opt|
-          output_path = copy_derivative_to_working_path(opt[:url], new_encode.id)
+          output_path = copy_derivative_to_working_path(opt[:url], opt[:label], new_encode.id)
           filename_label_hash[output_path] = opt[:label]
         end
 
@@ -286,8 +286,9 @@ module ActiveEncode
         ActiveEncode.sanitize_input(input_url)
       end
 
-      def copy_derivative_to_working_path(url, id)
-        output_path = working_path("outputs/#{ActiveEncode.sanitize_base url}#{File.extname url}", id)
+      def copy_derivative_to_working_path(url, label, id)
+        label_url = add_label_to_url(ActiveEncode.sanitize_base(url), label)
+        output_path = working_path("outputs/#{label_url}#{File.extname url}", id)
         if url.start_with? "s3://"
           # Use aws-sdk-s3 download_file method
           # Single request mode needed for compatibility with minio
@@ -296,6 +297,13 @@ module ActiveEncode
           FileUtils.cp FileLocator.new(url).location, output_path
         end
         output_path
+      end
+
+      def add_label_to_url(url, label)
+        return url if url.match?(/\-#{label}$/)
+
+        url.gsub!(/#{label}$/, '')
+        url + "-#{label}"
       end
     end
   end

--- a/lib/active_encode/engine_adapters/pass_through_adapter.rb
+++ b/lib/active_encode/engine_adapters/pass_through_adapter.rb
@@ -302,8 +302,7 @@ module ActiveEncode
       def add_label_to_url(url, label)
         return url if url.match?(/\-#{label}$/)
 
-        url.gsub!(/#{label}$/, '')
-        url + "-#{label}"
+        url.gsub(/#{label}$/, '') + "-#{label}"
       end
     end
   end

--- a/spec/integration/pass_through_adapter_spec.rb
+++ b/spec/integration/pass_through_adapter_spec.rb
@@ -297,5 +297,12 @@ describe ActiveEncode::EngineAdapters::PassThroughAdapter do
       it { is_expected.to be_failed }
       it { expect(subject.errors).to be_present }
     end
+
+    context 'output url' do
+      it 'adds `-#{label}` to end of output url' do
+        created_job
+        expect(File).to exist("#{work_dir}/#{created_job.id}/outputs/fireworks-low.mp4")
+      end
+    end
   end
 end


### PR DESCRIPTION
For the ffmpeg adapter, we add the passed in `label` value to the end of the output filename e.x. "filename-label.ext". While a label is passed in for the pass-through adapter as well we were not appending it to the filename, resulting in an inconsistency in how output urls were being generated between the two adapters.